### PR TITLE
Basic player oriented zonal marking

### DIFF
--- a/app/App.hs
+++ b/app/App.hs
@@ -17,6 +17,7 @@ import qualified Control.Concurrent.Async as Async
 import Football.Understanding.Space.Data (CentresOfPlayCache)
 import Football.Understanding.Interception.Data (InterceptionDataCache)
 import System.Random (randomRIO)
+import Football.Understanding.Zones.Types (ZoneCache)
 
 newtype AppM a = 
   AppM {unAppM :: ReaderT MatchState IO a}
@@ -66,6 +67,10 @@ instance Cache AppM CentresOfPlayCache where
 instance Cache AppM InterceptionDataCache where
   cacheLookup = cacheLookupInterceptionDataImpl
   cacheInsert = cacheInsertInterceptionDataImpl
+
+instance Cache AppM ZoneCache where
+  cacheLookup = cacheLookupZoneDataImpl
+  cacheInsert = cacheInsertZoneDataImpl
 
 
 runAppM :: AppM a -> MatchState -> IO a

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -352,6 +352,7 @@ loopFor r fonts fpsm = do
   icache <- newEmptyTMVarIO
   gametimer <- newTVarIO $ GameTime FirstHalf 0
   gamestate <- newTVarIO $ KickOff Team1
+  zonecache <- newEmptyTMVarIO
   let initialState = 
         MatchState 
           { matchStateBall = bt
@@ -366,6 +367,7 @@ loopFor r fonts fpsm = do
           , matchStateInterceptionCache = icache
           , matchStateGameTime = gametimer
           , matchStateGameState = gamestate
+          , matchStateZoneCache = zonecache
           }
   _ <- forkIO $ runAppM (processLoop processFps) initialState
   runAppM loop' initialState

--- a/src/Football/Behaviours/Marking/Zonal.hs
+++ b/src/Football/Behaviours/Marking/Zonal.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TupleSections #-}
+
+module Football.Behaviours.Marking.Zonal where
+
+import Control.Lens ((^.))
+import Football.Match 
+import Core (Cache, Log)
+import Football.Understanding.Zones.Types (ZoneCache)
+import Football.Types
+import Football.Understanding.Zones (getZoneMap, zonePolyForPlayer)
+import Football.Understanding.Space.Data (CentresOfPlayCache, SpacePoly (spacePolyJCV))
+import Voronoi.JCVoronoi (pointInPoly, JCVPoly (polyPoint))
+import Football.Locate2D (Locate2D(locate2D))
+import Data.Foldable (maximumBy)
+import Football.Understanding.ExpectedGoals (locationXG)
+import Data.Function (on)
+import Football.Understanding.Space (mostAdvancedPlayer)
+import Linear (V3(V3), R1 (_x))
+
+maxByMaybe :: (a -> a -> Ordering) -> [a] -> Maybe a
+maxByMaybe _ [] = Nothing
+maxByMaybe f xs = Just $ maximumBy f xs
+
+mostDangerousPlayerInZone :: (Match m, Monad m, Log m, Cache m ZoneCache, Cache m CentresOfPlayCache) => Player -> m (Maybe Player)
+mostDangerousPlayerInZone player = do
+  zmp <- getZoneMap (playerTeam player)
+  opps <- oppositionPlayers (playerTeam player)
+  let oppTeam = oppositionTeam (playerTeam player)
+  let maybePoly = zonePolyForPlayer player zmp
+  case maybePoly of
+    Just poly -> do
+      oppositionPlayersInPoly <- traverse (\p -> (p, ) <$> locationXG oppTeam p) $ filter (\op -> pointInPoly (locate2D op) (spacePolyJCV poly)) opps
+      let maybeMostDangerous = maxByMaybe (compare `on` snd) oppositionPlayersInPoly
+      pure $ fst <$> maybeMostDangerous
+    Nothing -> pure Nothing
+  

--- a/src/Football/Behaviours/Press.hs
+++ b/src/Football/Behaviours/Press.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 module Football.Behaviours.Press where
 
 import Football.Ball
@@ -8,10 +10,22 @@ import Data.List (sortOn, minimumBy, reverse, foldl', find)
 import qualified Data.Ord
 import Voronoi.JCVoronoi (JCVPoly(..))
 import Football.Locate2D (Locate2D(locate2D))
-import Football.Understanding.Space.Data (SpacePoly(spacePolyJCV, spacePolyPlayer), SpaceMap (SpaceMap))
+import Football.Understanding.Space.Data (SpacePoly(spacePolyJCV, spacePolyPlayer), SpaceMap (SpaceMap), CentresOfPlayCache)
 import qualified Data.Map as Map
-import Core (Log(..))
+import Core (Log(..), Cache)
 import Football.Behaviours.Kick (motionVectorForPassTo)
 import Data.Maybe (isNothing)
+import Football.Understanding.Zones.Types (ZoneCache)
+import Football.Types (Player (playerTeam, playerPositionVector), Ball (ballPositionVector))
+import Football.Behaviours.Marking.Zonal (mostDangerousPlayerInZone)
+import Football.Understanding.Shape (outOfPossessionDesiredPosition)
 
+coverShadowOfPlayerOrientedZonalMark :: (Monad m, Match m, Log m, Cache m CentresOfPlayCache, Cache m ZoneCache) => Player -> m (Double, Double)
+coverShadowOfPlayerOrientedZonalMark player = do
+  maybeMarkedPlayer <- mostDangerousPlayerInZone player
+  ball <- gameBall
+  let dir = normalize (ballPositionVector ball - playerPositionVector player)
+  case maybeMarkedPlayer of
+    Just markedPlayer -> pure $ locate2D $ playerPositionVector markedPlayer + dir * pure 2
+    Nothing -> outOfPossessionDesiredPosition player
 

--- a/src/Football/Understanding/Shape.hs
+++ b/src/Football/Understanding/Shape.hs
@@ -18,12 +18,6 @@ import Football.Pitch (Pitch(pitchLength, pitchWidth), pitchHalfwayLineX)
 import Football.Types
 import Football.Understanding.Space.Data (CentresOfPlayCache, CentresOfPlay (centresOfPlayBothTeams, centresOfPlayTeam1, centresOfPlayTeam2))
 
-data PositionSphere = PositionEllipse
-    { positionEllipseCentre :: (Double, Double)
-    , positionEllipseXAxis :: Double
-    , positionEllipseYAxis :: Double
-    }
-
 outOfPossessionFormationRelativeTo :: (Monad m, Match m) => Double -> Double -> Player -> (Double, Double) -> m (Double, Double)
 outOfPossessionFormationRelativeTo verticalCompactness horizontalCompactness player (uCentreX, uCentreY) = do
   attackingDirection' <- attackingDirection (playerTeam player)
@@ -31,16 +25,16 @@ outOfPossessionFormationRelativeTo verticalCompactness horizontalCompactness pla
   let (centreX, centreY) = invertIfNeeded pitch' attackingDirection' (uCentreX, uCentreY)
   let pos = case playerNumber player of
         1 -> inDirection  25   1     (-25*verticalCompactness) 0                              (centreX, centreY)
-        2 -> inDirection  62.5 5     (-15*verticalCompactness) (8+5*horizontalCompactness)    (centreX, centreY)
-        3 -> inDirection  62.5 5     (-15*verticalCompactness) (-8-5*horizontalCompactness)   (centreX, centreY)
-        4 -> inDirection  52.5 5     (-15*verticalCompactness) (3+5*horizontalCompactness)    (centreX, centreY)
-        5 -> inDirection  52.5 5     (-15*verticalCompactness) (-3-5*horizontalCompactness)   (centreX, centreY)
-        6 -> inDirection  65   10    (-10*verticalCompactness) 0                              (centreX, centreY)
-        10 -> inDirection 70   15    (-5*verticalCompactness)  (-3-5*horizontalCompactness)   (centreX, centreY)
-        8 -> inDirection  70   15    (-5*verticalCompactness)  (3+5*horizontalCompactness)    (centreX, centreY)
-        11 -> inDirection 85   20    (7*verticalCompactness)   (-5-5*horizontalCompactness)   (centreX, centreY)
-        7 -> inDirection  85   20    (7*verticalCompactness)   (5+5*horizontalCompactness)    (centreX, centreY)
-        9 -> inDirection  90   25    (9*verticalCompactness)   0                              (centreX, centreY)
+        2 -> inDirection  77.5 5     (-15*verticalCompactness) (8+5*horizontalCompactness)    (centreX, centreY)
+        3 -> inDirection  77.5 5     (-15*verticalCompactness) (-8-5*horizontalCompactness)   (centreX, centreY)
+        4 -> inDirection  62.5 5     (-15*verticalCompactness) (3+5*horizontalCompactness)    (centreX, centreY)
+        5 -> inDirection  62.5 5     (-15*verticalCompactness) (-3-5*horizontalCompactness)   (centreX, centreY)
+        6 -> inDirection  75   10    (-10*verticalCompactness) 0                              (centreX, centreY)
+        10 -> inDirection 90   15    (-5*verticalCompactness)  (-3-5*horizontalCompactness)   (centreX, centreY)
+        8 -> inDirection  90   15    (-5*verticalCompactness)  (3+5*horizontalCompactness)    (centreX, centreY)
+        11 -> inDirection 100   20    (7*verticalCompactness)   (-5-5*horizontalCompactness)   (centreX, centreY)
+        7 -> inDirection  100   20    (7*verticalCompactness)   (5+5*horizontalCompactness)    (centreX, centreY)
+        9 -> inDirection  105   25    (9*verticalCompactness)   0                              (centreX, centreY)
         _ -> inDirection  105  0     0    0                                                   (centreX, centreY)
   pure $ invertIfNeeded pitch' attackingDirection' pos
   where

--- a/src/Football/Understanding/Team.hs
+++ b/src/Football/Understanding/Team.hs
@@ -1,0 +1,29 @@
+module Football.Understanding.Team where
+
+import Control.Lens ((^.))
+import Linear (V3(..), R1 (_x), R3 (_z), R2 (_y))
+import Football.Match
+import Football.Types
+import Football.Pitch (Pitch(pitchLength, pitchWidth))
+
+toTeamCoordinateSystem :: (Match m, Monad m) => Team -> V3 Double -> m (V3 Double)
+toTeamCoordinateSystem team coord = do
+  attackingDirection' <- attackingDirection team
+  pitch' <- pitch
+  case attackingDirection' of
+    AttackingLeftToRight -> pure coord
+    AttackingRightToLeft -> pure $ V3 (pitchLength pitch' - coord ^. _x) (pitchWidth pitch' - coord ^. _y) (coord ^. _z)
+
+fromTeamCoordinateSystem :: (Match m, Monad m) => Team -> V3 Double -> m (V3 Double)
+fromTeamCoordinateSystem team coord = do
+  attackingDirection' <- attackingDirection team
+  pitch' <- pitch
+  case attackingDirection' of
+    AttackingLeftToRight -> pure coord
+    AttackingRightToLeft -> pure $ V3 (pitchLength pitch' - coord ^. _x) (pitchWidth pitch' - coord ^. _y) (coord ^. _z)
+
+inTeamCoordinateSystem :: (Match m, Monad m) => Team -> V3 Double -> (V3 Double -> V3 Double) -> m (V3 Double)
+inTeamCoordinateSystem team coord f = do
+  x <- toTeamCoordinateSystem team coord
+  fromTeamCoordinateSystem team (f x)
+    

--- a/src/Football/Understanding/Zones.hs
+++ b/src/Football/Understanding/Zones.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Football.Understanding.Zones where
+
+import Football.Match
+import Football.Understanding.Space.Data (SpacePoly (SpacePoly), CentresOfPlayCache)
+import Voronoi.JCVoronoi (jcvSites2, JCVPoly (polyIndex))
+import Football.Locate2D (Locate2D(locate2D))
+import Football.Player (playerControlCentre, isGoalKeeper)
+import qualified Data.Map as Map
+import Data.Foldable (Foldable(foldl'))
+import Football.Types
+import Football.Understanding.Zones.Types (ZoneMap(..), ZoneCache)
+import Core (cached, Cache, Log)
+import Football.Understanding.Shape (outOfPossessionDesiredPosition)
+
+createZonalMap :: (Match m, Monad m, Log m, Cache m CentresOfPlayCache) => Team -> m ZoneMap
+createZonalMap team = do
+  players' <- filter (not . isGoalKeeper) <$> teamPlayers team
+  pos <- traverse outOfPossessionDesiredPosition players'
+  let allPlayersVoronoi = jcvSites2 pos
+  let map1 = Map.fromList $ fmap (\v -> (polyIndex v, v)) allPlayersVoronoi
+  let folder acc (i, p) =
+        case Map.lookup i map1 of
+          Just poly -> Map.insert p (SpacePoly poly p) acc
+          Nothing -> acc
+  let map2 = foldl' folder Map.empty $ zip [0..]  players'
+  pure $ ZoneMap map2
+
+zonePolyForPlayer :: Player -> ZoneMap -> Maybe SpacePoly
+zonePolyForPlayer player (ZoneMap zp) = Map.lookup player zp
+
+getZoneMap :: (Match m, Monad m, Log m, Cache m ZoneCache, Cache m CentresOfPlayCache ) => Team -> m ZoneMap
+getZoneMap team = do 
+  cached createZonalMap team
+

--- a/src/Football/Understanding/Zones/Types.hs
+++ b/src/Football/Understanding/Zones/Types.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Football.Understanding.Zones.Types where
+
+import Core (CacheKeyValue (CacheKey, CacheValue))
+import Football.Types (Team, Player)
+import Football.Understanding.Space.Data (SpacePoly)
+import Data.Map (Map)
+
+newtype ZoneMap = ZoneMap (Map Player SpacePoly)
+
+data ZoneCache = ZoneCache
+
+instance CacheKeyValue ZoneCache where
+  type CacheKey ZoneCache = Team
+  type CacheValue ZoneCache = ZoneMap

--- a/tiki-tech.cabal
+++ b/tiki-tech.cabal
@@ -68,6 +68,7 @@ library
         Football.Behaviours.FindSpace
         Football.Behaviours.Kick
         Football.Behaviours.Marking
+        Football.Behaviours.Marking.Zonal
         Football.Behaviours.Pass
         Football.Behaviours.Press
         Football.Behaviours.Shoot
@@ -93,6 +94,9 @@ library
         Football.Understanding.Shape
         Football.Understanding.Space
         Football.Understanding.Space.Data
+        Football.Understanding.Team
+        Football.Understanding.Zones
+        Football.Understanding.Zones.Types
         Voronoi.JCVoronoi
         Core
 


### PR DESCRIPTION
Implements a basic version of player oriented zonal marking from #1 

- The pitch is divided into 10 zones (one for each outfield player) for each team.
- Players will mark the most dangerous* player in their zone.
  - They will stand either 2 metres closer to the goal or 2 metres closer to the ball than their opponent.
- If there is no opponent within their zone, they will adopt the position assigned by the formation.

*danger is defined by expected goal value in that position.