### PR TITLE
Add line-breaking passes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -406,8 +406,8 @@ loopFor r fonts fpsm = do
       -- (SpaceMap t1Sites) <- getSpaceMapForTeam Team1
       -- traverse_ (liftIO . render r (fontsDefault fonts)) $ fmap snd $ Map.toList t1Sites
 
-      (SpaceMap t2Sites) <- getSpaceMapForTeam Team2
-      traverse_ (liftIO . render r (fontsDefault fonts)) $ fmap snd $ Map.toList t2Sites
+      -- (SpaceMap t2Sites) <- getSpaceMapForTeam Team2
+      -- traverse_ (liftIO . render r (fontsDefault fonts)) $ fmap snd $ Map.toList t2Sites
 
       --draw zone polygons
       -- (ZoneMap sitesAll) <- getZoneMap Team1

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -42,7 +42,9 @@ import qualified Text.Printf as TText
 import Football.Events.Goal (score)
 import Football.Understanding.Zones (getZoneMap)
 import Football.Understanding.Zones.Types (ZoneMap(ZoneMap))
-import Football.Understanding.Space (getSpaceMapForTeam)
+import Football.Understanding.Space (getSpaceMapForTeam, offsideLine)
+import Football.Understanding.LineBreaking (oppositionLines)
+import Football.Locate2D (Locate2D(locate2D))
 
 black :: SP.Color
 black = V4 0 0 0 255
@@ -404,12 +406,22 @@ loopFor r fonts fpsm = do
       -- (SpaceMap t1Sites) <- getSpaceMapForTeam Team1
       -- traverse_ (liftIO . render r (fontsDefault fonts)) $ fmap snd $ Map.toList t1Sites
 
-      -- (SpaceMap t2Sites) <- getSpaceMapForTeam Team2
-      -- traverse_ (liftIO . render r (fontsDefault fonts)) $ fmap snd $ Map.toList t2Sites
+      (SpaceMap t2Sites) <- getSpaceMapForTeam Team2
+      traverse_ (liftIO . render r (fontsDefault fonts)) $ fmap snd $ Map.toList t2Sites
 
-      -- draw zone polygons
+      --draw zone polygons
       -- (ZoneMap sitesAll) <- getZoneMap Team1
       -- traverse_ (liftIO . render r (fontsDefault fonts)) $ fmap snd $ Map.toList sitesAll
+
+      -- offside1X <- offsideLine Team1
+      -- liftIO $ render r (fontsDefault fonts) (OffsideLine offside1X)
+      -- offside2X <- offsideLine Team2
+      -- liftIO $ render r (fontsDefault fonts) (OffsideLine offside2X)
+
+
+      -- lines <- oppositionLines Team1 
+      -- let lines' = fmap (\(l1, l2) -> DefLine l1 l2) lines
+      -- traverse_ (liftIO . render r (fontsDefault fonts)) lines'
 
       -- draw the scores
       (lg, mg) <- score

--- a/app/Render.hs
+++ b/app/Render.hs
@@ -2,6 +2,8 @@
 module Render  
   ( Render(..)
   , Pitch(..)
+  , OffsideLine(..)
+  , DefLine(..)
   ) where
 
 import qualified SDL as S
@@ -239,5 +241,21 @@ renderIntention r pos i = pure ()
 
 
 
+newtype OffsideLine = OffsideLine Double
+
+instance Render OffsideLine where
+  render :: S.Renderer -> SDLFont.Font -> OffsideLine -> IO ()
+  render r _ (OffsideLine x) = do
+    let lp1 = coordinateTransV $ V2 x (-34)
+    let lp2 = coordinateTransV $ V2 x 34
+    SP.line r lp1 lp2 grey
 
 
+data DefLine = DefLine (V2 Double) (V2 Double)
+
+instance Render DefLine where
+  render :: S.Renderer -> SDLFont.Font -> DefLine -> IO ()
+  render r _ (DefLine p1 p2) = do
+    let lp1 = coordinateTransV p1
+    let lp2 = coordinateTransV p2
+    SP.line r lp1 lp2 grey

--- a/src/Football/Behaviours/Kick.hs
+++ b/src/Football/Behaviours/Kick.hs
@@ -72,7 +72,7 @@ controlBall loc player = do
     kickSuccess kickLoc player' = do
       ball <- gameBall
       mult <- randomNormalMeanStd 1.0 0.05
-      ball' <- kickBall player kickLoc $ (- ballMotionVector ball + playerMotionVector player') * pure mult
+      ball' <- kickBall player kickLoc $ (- ballMotionVector ball + playerMotionVector player' * 0.8) * pure mult
       time <- currentGameTime
       let cooldownTime = 0.1
       let eBallPos = ballPositionVector ball' + ballMotionVector ball' * pure cooldownTime

--- a/src/Football/Intentions/OnTheBall.hs
+++ b/src/Football/Intentions/OnTheBall.hs
@@ -20,7 +20,7 @@ import Football.Types
 import qualified Data.Vector as Vector
 import qualified Statistics.Distribution.Normal as ND
 import Statistics.Distribution (Distribution(cumulative))
-import Linear (V2(V2), project, normalize, Metric (dot), V3 (V3), V4 (V4))
+import Linear (V2(V2), project, normalize, Metric (dot, norm), V3 (V3), V4 (V4))
 import Data.Time.Clock.System (SystemTime(systemNanoseconds))
 import Football.GameTime (gameTimeAddSeconds)
 import Football.Understanding.Space.Data (SpaceCache)
@@ -46,19 +46,23 @@ cumulativeProbabilityValue mean sd value =
 onTheBallOptionDesirabilityCoeff :: OnTheBallOption -> Double
 onTheBallOptionDesirabilityCoeff (DribbleOption dd) =
   let zXGAdded = min 3.5 $ (dribbleXGAdded dd * dribbleSafetyCoeff dd - 0.000833333333333) / 0.09
-      zOppXGAdded = min 3.5 $ (dribbleOppositionXGAdded dd * (1 - dribbleSafetyCoeff dd) + 0.000833333333333) / 0.15
+      zOppXGAdded = - (min 3.5 $ (dribbleOppositionXGAdded dd * (1 - dribbleSafetyCoeff dd) + 0.000833333333333) / 0.15)
       zSafety = min 3.5 $ (dribbleSafetyCoeff dd - 1) / 0.01
       v = V3 zXGAdded zSafety zOppXGAdded
-      proj = (1/sqrt 3) * v `dot` V3 1 1 (-1)
+      ws = V3 1.0 1 0.4
+      wt = ws `dot` V3 1 1 1
+      proj = v `dot` (ws / pure wt) / norm (ws / pure wt)
       unitND = ND.normalDistr 0 1
   in cumulative unitND proj
 onTheBallOptionDesirabilityCoeff (PassOption pd) =
-  let zXGAdded = min 3.5 $ (passXGAdded pd * passSafetyCoeff pd - 0.000833333333333) / 0.1
-      zOppXGAdded = min 3.5 $ (passOppositionXGAdded pd * (1 - passSafetyCoeff pd)  +  0.000833333333333) / 0.15
-      zSafety = min 3.5 $ (passSafetyCoeff pd - 0.85) / 0.08
-      zLinesBroken = min 3.5 $ (passBrokenLines pd - 0.2) / 0.25
+  let zXGAdded = min 5 $ (passXGAdded pd * passSafetyCoeff pd - 0.000833333333333) / 0.1
+      zSafety = min 5 $ (passSafetyCoeff pd - 0.85) / 0.08
+      zOppXGAdded = - (min 5 $ (passOppositionXGAdded pd * (1 - passSafetyCoeff pd)  +  0.000833333333333) / 0.15)
+      zLinesBroken = min 5 $ (passBrokenLines pd * passSafetyCoeff pd - 0.2) / 0.25
       v = V4 zXGAdded zSafety zOppXGAdded zLinesBroken
-      proj = (1/sqrt 4) * v `dot` V4 1 1 (-1) 1
+      ws = V4 1.0 1 0.4 1
+      wt = ws `dot` V4 1 1 1 1
+      proj = v `dot` (ws / pure wt) / norm (ws / pure wt)
       unitND = ND.normalDistr 0 1
   in cumulative unitND proj
 onTheBallOptionDesirabilityCoeff (ShotOption sd) = 

--- a/src/Football/Maths.hs
+++ b/src/Football/Maths.hs
@@ -13,6 +13,33 @@ linePlaneIntersection (l0, l) (p0, n) =
       let d = (p0-l0) `dot` n' / l' `dot` n'
       in Just $ l0 + pure d * l'
 
+linePlaneIntersection2D :: (V2 Double, V2 Double) -> (V2 Double, V2 Double) -> Maybe (V2 Double)
+linePlaneIntersection2D (l0, l) (p0, n) =
+  let l' = normalize l
+      n' = normalize n
+  in 
+    if (p0 - l0) `dot` n' == 0 then
+      Nothing
+    else
+      let d = (p0-l0) `dot` n' / l' `dot` n'
+      in Just $ l0 + pure d * l'
+
+lineSegmentPlaneIntersection2D :: (V2 Double, V2 Double) -> (V2 Double, V2 Double) -> Maybe (V2 Double)
+lineSegmentPlaneIntersection2D (l0, l1) (p0, n) =
+  let l = (l1-l0)
+      l' = normalize l
+      n' = normalize n
+  in 
+    if (p0 - l0) `dot` n' == 0 then
+      Nothing
+    else
+      let d = (p0-l0) `dot` n' / l' `dot` n'
+      in 
+        if d >= 0 && d <= norm l then
+          Just $ l0 + pure d * l'
+        else
+          Nothing
+
 lineLineIntersection :: (V2 Double, V2 Double) -> (V2 Double, V2 Double) -> Maybe (V2 Double)
 lineLineIntersection (V2 x1 y1, V2 x2 y2) (V2 x3 y3, V2 x4 y4) =
   let td = (x1-x3)*(y3-y4) - (y1-y3)*(x3-x4)

--- a/src/Football/Understanding/LineBreaking.hs
+++ b/src/Football/Understanding/LineBreaking.hs
@@ -19,13 +19,10 @@ import Football.Maths (lineLineIntersection, linePlaneIntersection, linePlaneInt
 import Football.Understanding.Pitch (targetGoalVector)
 import Football.Locate2D (Locate2D(locate2D))
 
-
 oppositionLines :: (Monad m, Match m, Cache m SpaceCache) => Team -> m [(V2 Double, V2 Double)]
 oppositionLines team = do
   (SpaceMap spaceMap') <- getSpaceMapForTeam $ oppositionTeam team
-
   ball <- gameBall
-
   tgVec <- targetGoalVector team
   let tgVec2D = tgVec ^. _xy
       tgVec2D' = tgVec2D - locate2D ball
@@ -40,7 +37,6 @@ oppositionLines team = do
         in case res of
           p1 : p2 : _ -> (p1, p2) : acc
             
-
   pure $ foldl' lineFolder [] $ Map.toList spaceMap'
 
 linesBroken :: (Monad m, Match m, Cache m SpaceCache, Log m) => Team -> (V2 Double, V2 Double)  -> m Double

--- a/src/Football/Understanding/LineBreaking.hs
+++ b/src/Football/Understanding/LineBreaking.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Football.Understanding.LineBreaking where
+
+import Control.Lens ((^.))
+import Football.Match
+import Football.Understanding.Space.Data (SpaceMap (SpaceMap), SpaceCache, SpacePoly (spacePolyJCV, spacePolyPlayer))
+import Linear (V2 (V2), Metric (dot, norm), R1 (_x), R2 (_y, _xy), normalize)
+import Core (Cache, Log (logOutput))
+import Football.Types 
+import Football.Understanding.Space (getSpaceMapForTeam)
+import Voronoi.JCVoronoi (JCVEdge(..), JCVPoly (polyEdges, polyIndex))
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Data.Map ((!))
+import Data.List (foldl')
+import Data.Maybe (isJust, maybeToList)
+import Football.Maths (lineLineIntersection, linePlaneIntersection, linePlaneIntersection2D, lineSegmentPlaneIntersection2D)
+import Football.Understanding.Pitch (targetGoalVector)
+import Football.Locate2D (Locate2D(locate2D))
+
+
+oppositionLines :: (Monad m, Match m, Cache m SpaceCache) => Team -> m [(V2 Double, V2 Double)]
+oppositionLines team = do
+  (SpaceMap spaceMap') <- getSpaceMapForTeam $ oppositionTeam team
+
+  ball <- gameBall
+
+  tgVec <- targetGoalVector team
+  let tgVec2D = tgVec ^. _xy
+      tgVec2D' = tgVec2D - locate2D ball
+      tgVecDir2D = normalize tgVec2D'
+      tgVecPerp2D = V2 (- tgVecDir2D ^. _y) (tgVecDir2D ^. _x)
+
+  let lineFolder acc (_, poly) =
+        let edges = polyEdges . spacePolyJCV $ poly
+            playerLoc = locate2D $ spacePolyPlayer poly
+            res = concatMap (\e -> maybeToList $ lineSegmentPlaneIntersection2D (jcvEdgePoint1 e, jcvEdgePoint2 e) (playerLoc, tgVecDir2D) ) edges
+
+        in case res of
+          p1 : p2 : _ -> (p1, p2) : acc
+            
+
+  pure $ foldl' lineFolder [] $ Map.toList spaceMap'
+
+linesBroken :: (Monad m, Match m, Cache m SpaceCache, Log m) => Team -> (V2 Double, V2 Double)  -> m Double
+linesBroken team line = do
+  oppLines <- oppositionLines team
+  let (lv1, lv2) = line
+      lv' = lv2 - lv1
+      ld = normalize lv'
+
+  tgVec <- targetGoalVector team
+  let tgVec2D = tgVec ^. _xy
+      tgVec2D' = tgVec2D - lv1
+      tgVecDir2D = normalize tgVec2D'
+
+  let crossedOppositionLines = length $  filter (\(lp1, lp2) -> isJust $ lineLineIntersection (lp1, lp2) (lv1, lv2)   )   oppLines
+  let oppositionLinesToGoal = length $ filter (\(lp1, lp2) -> isJust $ lineLineIntersection (lp1, lp2) (lv1, tgVec2D)   )   oppLines 
+  let adjustedOppositionLines = (ld `dot` tgVecDir2D) * fromIntegral crossedOppositionLines
+
+  pure $ adjustedOppositionLines / fromIntegral oppositionLinesToGoal

--- a/src/Football/Understanding/Pitch.hs
+++ b/src/Football/Understanding/Pitch.hs
@@ -5,7 +5,6 @@ import Football.Match
 import Football.Match (AttackingDirection(AttackingRightToLeft))
 import Football.Pitch (rightGoalLine, leftGoalLine)
 
-
 ownGoalVector :: (Monad m, Match m) => Team -> m (V3 Double)
 ownGoalVector team = do
   ad <- attackingDirection team
@@ -17,5 +16,8 @@ ownGoalVector team = do
     AttackingRightToLeft -> do
       let (lgMin, lgMax) = rightGoalLine pitch'
       pure $ (lgMin + lgMax) / 2
+
+targetGoalVector :: (Monad m, Match m) => Team -> m (V3 Double)
+targetGoalVector team = ownGoalVector (oppositionTeam team)
 
 

--- a/src/Football/Understanding/Shape.hs
+++ b/src/Football/Understanding/Shape.hs
@@ -29,12 +29,12 @@ outOfPossessionFormationRelativeTo verticalCompactness horizontalCompactness pla
         3 -> inDirection  27.5    (-52)   (-15*verticalCompactness) (-8-5*horizontalCompactness)   (centreX, centreY)
         4 -> inDirection  12.5    (-52)   (-15*verticalCompactness) (3+5*horizontalCompactness)    (centreX, centreY)
         5 -> inDirection  12.5    (-52)   (-15*verticalCompactness) (-3-5*horizontalCompactness)   (centreX, centreY)
-        6 -> inDirection  25      (-52)   (-10*verticalCompactness) 0                              (centreX, centreY)
-        10 -> inDirection 37      (-52)   (-5*verticalCompactness)  (-3-5*horizontalCompactness)   (centreX, centreY)
-        8 -> inDirection  37      (-52)   (-5*verticalCompactness)  (3+5*horizontalCompactness)    (centreX, centreY)
-        11 -> inDirection 47      (-52)   (7*verticalCompactness)   (-5-5*horizontalCompactness)   (centreX, centreY)
-        7 -> inDirection  47      (-52)   (7*verticalCompactness)   (5+5*horizontalCompactness)    (centreX, centreY)
-        9 -> inDirection  52      (-52)   (9*verticalCompactness)   0                              (centreX, centreY)
+        6 -> inDirection  25      (-52)   (-7.5*verticalCompactness) 0                              (centreX, centreY)
+        10 -> inDirection 37      (-52)   (0)                       (-3-5*horizontalCompactness)   (centreX, centreY)
+        8 -> inDirection  37      (-52)   (0)                       (3+5*horizontalCompactness)    (centreX, centreY)
+        11 -> inDirection 47      (-52)   (10*verticalCompactness)   (-5-5*horizontalCompactness)   (centreX, centreY)
+        7 -> inDirection  47      (-52)   (10*verticalCompactness)   (5+5*horizontalCompactness)    (centreX, centreY)
+        9 -> inDirection  52      (-52)   (10*verticalCompactness)   0                              (centreX, centreY)
         _ -> inDirection  52      0  0                              0                              (centreX, centreY)
   fromTeamCoordinateSystem2D (playerTeam player) pos
   where

--- a/src/Football/Understanding/Space.hs
+++ b/src/Football/Understanding/Space.hs
@@ -17,7 +17,7 @@ import Football.Understanding.Space.Data (SpaceMap(..), SpacePoly (..), Horizont
 import qualified Data.Vector as Vec
 import Statistics.Quantile (median, medianUnbiased)
 import Data.Ord (comparing, Down(..))
-import Football.Pitch (pitchHalfwayLineX)
+import Football.Pitch (pitchHalfwayLineX, pitchHalfLengthX)
 import Core (Cache, cached, CacheKeyValue (CacheKey, CacheValue))
 import Football.Player (playerControlCentre)
 import Linear.V3 (_x)
@@ -110,15 +110,14 @@ mostAdvancedPlayer team = do
 offsideLine :: (Match m, Monad m) => Team -> m Double
 offsideLine team  = do
   pitch' <- pitch
-  teamPlayers' <- teamPlayers $ otherTeam team
+  teamPlayers' <- teamPlayers $ oppositionTeam team
   attackingDirection' <- attackingDirection team
   (V2 ballX _) <- locate2D <$> gameBall
+
   pure $ case attackingDirection' of
-       AttackingLeftToRight -> min (pitchLength pitch')  $ max ballX                      $ max (pitchHalfwayLineX pitch') $ xPos (sortOn (Data.Ord.Down . xPos) teamPlayers' !! 1)
-       AttackingRightToLeft -> min ballX                 $ min (pitchHalfwayLineX pitch') $ max 0                          $ xPos (sortOn xPos teamPlayers' !! 1                  ) 
+       AttackingLeftToRight -> min (pitchLength pitch')  $ max ballX                      $ max (pitchHalfwayLineX pitch')  $ xPos (sortOn (Data.Ord.Down . xPos) teamPlayers' !! 1)
+       AttackingRightToLeft -> min ballX                 $ min 0                          $ max (- pitchHalfLengthX pitch') $ xPos (sortOn xPos teamPlayers' !! 1                  ) 
   where 
-    otherTeam Team1 = Team2
-    otherTeam Team2 = Team1
     xPos player = locate2D player ^. _x
 
 isOffide :: (Match m, Monad m, Locate2D x) => Team -> x -> m Bool

--- a/test/Football/Behaviours/PassSpec.hs
+++ b/test/Football/Behaviours/PassSpec.hs
@@ -9,10 +9,12 @@ import Football.Match (Match(..), AttackingDirection (AttackingLeftToRight, Atta
 import Football.Behaviours.Pass
 import Linear (V3(V3), normalize)
 import Control.Monad.Reader (ReaderT (runReaderT), MonadIO (liftIO), MonadReader (..), asks)
-import Core (Log (logOutput))
+import Core
 import Data.List (sortOn)
 import qualified Data.Ord
 import Football.Types
+import Football.Understanding.Space.Data (SpaceCache)
+import Data.Maybe (Maybe(Nothing))
 
 defaultPlayerSpeed :: PlayerSpeed
 defaultPlayerSpeed =
@@ -37,7 +39,6 @@ instance MonadReader PassSpecContext PassSpecM where
   ask = PassSpecM ask
   local f (PassSpecM x) = PassSpecM $ local f x
 
-
 instance Match PassSpecM where
   attackingDirection Team1 = pure AttackingLeftToRight
   attackingDirection Team2 = pure AttackingRightToLeft
@@ -47,6 +48,10 @@ instance Match PassSpecM where
 
 instance Log PassSpecM where
   logOutput stuff = liftIO $ print stuff
+
+instance Cache PassSpecM SpaceCache where
+  cacheLookup _ = pure Nothing
+  cacheInsert _ _ = pure ()
 
 playerWithBallAtOrigin :: Player
 playerWithBallAtOrigin = 

--- a/test/Football/Intentions/OnTheBallSpec.hs
+++ b/test/Football/Intentions/OnTheBallSpec.hs
@@ -29,7 +29,7 @@ onTheBallTests = testGroup "Desirability calculation tests"
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption unreliablePass
 
-        coeff @?= 1.1445182876038281e-6
+        coeff @?= 3.1008089177420917e-9
     , testCase "A very reliable pass should have high desirability" $ do
         let reliablePass = PassDesirability
               { passTarget = SpaceTarget (V2 0 0)
@@ -44,7 +44,7 @@ onTheBallTests = testGroup "Desirability calculation tests"
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption reliablePass
 
-        coeff @?= 0.6249027308313191
+        coeff @?= 0.6203580259263135
     , testCase "A very reliable pass with high XG should have very high desirability" $ do
         let reliablePass = PassDesirability
               { passTarget = SpaceTarget (V2 0 0)
@@ -59,7 +59,7 @@ onTheBallTests = testGroup "Desirability calculation tests"
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption reliablePass
 
-        coeff @?= 0.9374092252263341
+        coeff @?= 0.9528760087568101
     , testCase "A 50/50 pass with high XG should have medium desirability" $ do
         let reliablePass = PassDesirability
               { passTarget = SpaceTarget (V2 0 0)
@@ -74,7 +74,7 @@ onTheBallTests = testGroup "Desirability calculation tests"
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption reliablePass
 
-        coeff @?= 0.4927654866500457
+        coeff @?= 0.40781117835385866
 
 
     ]

--- a/test/Football/Intentions/OnTheBallSpec.hs
+++ b/test/Football/Intentions/OnTheBallSpec.hs
@@ -24,11 +24,12 @@ onTheBallTests = testGroup "Desirability calculation tests"
               , passSafetyCoeff = 7.59750720556321e-2
               , passXGAdded = 1.0515178437939708e-10
               , passOppositionXGAdded = -3.84819110288071e-2
+              , passBrokenLines = 0.2
               }
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption unreliablePass
 
-        coeff @?= 2.4185240092431006e-8
+        coeff @?= 1.1445182876038281e-6
     , testCase "A very reliable pass should have high desirability" $ do
         let reliablePass = PassDesirability
               { passTarget = SpaceTarget (V2 0 0)
@@ -38,11 +39,12 @@ onTheBallTests = testGroup "Desirability calculation tests"
               , passSafetyCoeff = 0.9
               , passXGAdded = 1.0515178437939708e-10
               , passOppositionXGAdded = -3.84819110288071e-2
+              , passBrokenLines = 0.2
               }
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption reliablePass
 
-        coeff @?= 0.6434279866039837
+        coeff @?= 0.6249027308313191
     , testCase "A very reliable pass with high XG should have very high desirability" $ do
         let reliablePass = PassDesirability
               { passTarget = SpaceTarget (V2 0 0)
@@ -52,11 +54,12 @@ onTheBallTests = testGroup "Desirability calculation tests"
               , passSafetyCoeff = 0.9
               , passXGAdded = 0.27
               , passOppositionXGAdded = -3.84819110288071e-2
+              , passBrokenLines = 0.2
               }
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption reliablePass
 
-        coeff @?= 0.9616862136978284
+        coeff @?= 0.9374092252263341
     , testCase "A 50/50 pass with high XG should have medium desirability" $ do
         let reliablePass = PassDesirability
               { passTarget = SpaceTarget (V2 0 0)
@@ -66,11 +69,12 @@ onTheBallTests = testGroup "Desirability calculation tests"
               , passSafetyCoeff = 0.6
               , passXGAdded = 0.5
               , passOppositionXGAdded = -3.84819110288071e-2
+              , passBrokenLines = 0.2
               }
         
         let coeff = onTheBallOptionDesirabilityCoeff $ PassOption reliablePass
 
-        coeff @?= 0.4916464561650526
+        coeff @?= 0.4927654866500457
 
 
     ]

--- a/test/Football/Understanding/LineBreakingSpec.hs
+++ b/test/Football/Understanding/LineBreakingSpec.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Football.Understanding.LineBreakingSpec where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Football.Match (Match(..), AttackingDirection (..))
+import Football.Types
+import Football.Understanding.Space (pitchHorizontalZone)
+import Football.Understanding.Space.Data
+import Football.Understanding.Space.Data (HorizontalZone(CentreHZ))
+import Control.Monad.Cont (MonadIO)
+import Control.Monad.Reader (ReaderT (runReaderT), MonadReader (ask, local), asks)
+import Core (Cache(..))
+import Linear (V3(V3), V2 (V2))
+import Football.Understanding.LineBreaking (oppositionLines)
+
+defaultPlayerSpeed :: PlayerSpeed
+defaultPlayerSpeed =
+  PlayerSpeed
+    { playerSpeedAcceleration = 1.3
+    , playerSpeedMax = 7.9
+    }
+
+data LineBreakingSpecContext = 
+  LineBreakingSpecContext
+    { lbPlayers :: [Player]
+    , lbBall :: Ball
+    }
+
+newtype LineBreakingSpecM a = LineBreakingSpecM (ReaderT LineBreakingSpecContext IO a) deriving (Functor, Applicative, Monad, MonadIO)
+
+runLineBreakingSpecM :: LineBreakingSpecContext -> LineBreakingSpecM a -> IO a
+runLineBreakingSpecM pc (LineBreakingSpecM m) = runReaderT m pc
+
+instance MonadReader LineBreakingSpecContext LineBreakingSpecM where
+  ask = LineBreakingSpecM ask
+  local f (LineBreakingSpecM x) = LineBreakingSpecM $ local f x
+
+instance Match LineBreakingSpecM where
+  attackingDirection Team1 = pure AttackingLeftToRight
+  attackingDirection Team2 = pure AttackingRightToLeft
+  gameBall = asks lbBall
+  allPlayers = asks lbPlayers
+  pitch = pure $ Pitch 105 68
+
+instance Cache LineBreakingSpecM SpaceCache where
+  cacheLookup _ = pure Nothing
+  cacheInsert _ _ = pure ()
+
+
+dmPlayer :: Player
+dmPlayer = 
+  Player 
+    { playerPositionVector = V3 30 0 0
+    , playerMotionVector = V3 0 0 0
+    , playerNumber = 6
+    , playerSpeed = defaultPlayerSpeed
+    , playerIntention = DoNothing
+    , playerTeam = Team2 
+    }
+
+leftCMPlayer :: Player
+leftCMPlayer = 
+  Player 
+    { playerPositionVector = V3 25 8 0
+    , playerMotionVector = V3 0 0 0
+    , playerNumber = 10
+    , playerSpeed = defaultPlayerSpeed
+    , playerIntention = DoNothing
+    , playerTeam = Team2 
+    }
+
+rightCMPlayer :: Player
+rightCMPlayer = 
+  Player 
+    { playerPositionVector = V3 25 (-8) 0
+    , playerMotionVector = V3 0 0 0
+    , playerNumber = 8
+    , playerSpeed = defaultPlayerSpeed
+    , playerIntention = DoNothing
+    , playerTeam = Team2 
+    }
+
+fwPlayer :: Player
+fwPlayer = 
+  Player 
+    { playerPositionVector = V3 10 0 0
+    , playerMotionVector = V3 0 0 0
+    , playerNumber = 9
+    , playerSpeed = defaultPlayerSpeed
+    , playerIntention = DoNothing
+    , playerTeam = Team2 
+    }
+
+ball :: Ball
+ball = 
+  Ball
+    { ballPositionVector = V3 0.25 0 0
+    , ballMotionVector = V3 0 0 0
+    }
+
+lineBreakingSpecTests :: TestTree
+lineBreakingSpecTests = testGroup "LineBreakingSpec tests"
+  [ testCase "Opposition Lines for a single player should cross the pitch (-y, +y) at that player's location" $ do
+      let testContext =
+            LineBreakingSpecContext
+              { lbPlayers = [ dmPlayer ]
+              , lbBall = ball
+              }
+
+      lines <- runLineBreakingSpecM testContext $ oppositionLines Team1
+
+      lines @?= [(V2 30.0 39.0, V2 30.0 (-39.0))]
+  , testCase "Opposition Lines for two players in a line toward the goal should cross the pitch (-y, +y) at those players' locations" $ do
+      let testContext =
+            LineBreakingSpecContext
+              { lbPlayers = [ dmPlayer, fwPlayer ]
+              , lbBall = ball
+              }
+
+      lines <- runLineBreakingSpecM testContext $ oppositionLines Team1
+
+      lines @?= [(V2 10.0 (-39.0), V2 10.0 39.0), (V2 30.0 39.0, V2 30.0 (-39.0))]
+  , testCase "Opposition Lines for two players in a line side by side should split the pitch in two in the y direction, meeting in the centre" $ do
+      let testContext =
+            LineBreakingSpecContext
+              { lbPlayers = [ leftCMPlayer, rightCMPlayer ]
+              , lbBall = ball
+              }
+
+      lines <- runLineBreakingSpecM testContext $ oppositionLines Team1
+
+      lines @?= [(V2 25.0 (-39.0),V2 25.0 0.0),(V2 25.0 39.0,V2 25.0 0.0)]
+
+
+
+  ]
+

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,9 +7,10 @@ import Football.Behaviours.PassSpec (passTests)
 import Football.MathsSpec (mathsTests)
 import Football.Intentions.OnTheBallSpec (onTheBallTests)
 import Football.Understanding.ExpectedGoalsSpec (expectedGoalsSpecTests)
+import Football.Understanding.LineBreakingSpec (lineBreakingSpecTests)
 
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Tests" [spaceSpecTests, passTests, mathsTests, onTheBallTests, expectedGoalsSpecTests]
+tests = testGroup "Tests" [spaceSpecTests, passTests, mathsTests, onTheBallTests, expectedGoalsSpecTests, lineBreakingSpecTests]

--- a/tiki-tech.cabal
+++ b/tiki-tech.cabal
@@ -91,6 +91,7 @@ library
         Football.Understanding.ExpectedGoals
         Football.Understanding.Interception
         Football.Understanding.Interception.Data
+        Football.Understanding.LineBreaking
         Football.Understanding.Pitch
         Football.Understanding.Shape
         Football.Understanding.Space

--- a/tiki-tech.cabal
+++ b/tiki-tech.cabal
@@ -188,6 +188,7 @@ test-suite tiki-tech-test
       Football.Behaviours.PassSpec
       Football.Intentions.OnTheBallSpec
       Football.Understanding.ExpectedGoalsSpec
+      Football.Understanding.LineBreakingSpec
       Football.Understanding.SpaceSpec
       Football.MathsSpec
 


### PR DESCRIPTION
An attempt to better value passes.

Using xg does not work well in most situations because the values are far too small across most of the pitch. Using pitch static values also neglects the value of getting in behind the opposition when defenders are high up the pitch.

This is an attempt to solve that problem by creating defensive lines perpendicular to the vector between the ball and the goal that cross the voronoi zones of each defender (these are shown as grey lines in the picture).

Passing through many of these lines (e.g. green arrow) represents good progress being made at playing through the opposition while passes perpendicular (orange) or even opposite to the direction of progress (red) represent less progress and are consequently considered less valuable.

![breaking lines example](https://github.com/TheInnerLight/tiki-tech/assets/13356716/fefc6bfa-b818-4d3a-a010-7b7a82640da8)
